### PR TITLE
cmake: set default to OFF for RobotDynamicsEstimator, FloatingBaseEstimators, and JointTorqueControlDevice

### DIFF
--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -209,7 +209,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_RobotInterface
   "" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_FloatingBaseEstimators
-  "Compile FloatingBaseEstimators libraries?" ON
+  "Compile FloatingBaseEstimators libraries?" OFF
   "FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_Contact" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_ManifConversions
@@ -217,7 +217,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_ManifConversions
   "FRAMEWORK_USE_manif" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_RobotDynamicsEstimator
-  "Compile RobotDynamicsEstimator libraries?" ON
+  "Compile RobotDynamicsEstimator libraries?" OFF
   "FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif;FRAMEWORK_USE_BayesFilters" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_matioCppConversions
@@ -293,7 +293,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_YarpRobotLoggerDevice
   "FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_Camera;FRAMEWORK_COMPILE_YarpUtilities;FRAMEWORK_USE_robometry;FRAMEWORK_USE_trintrin" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_JointTorqueControlDevice
-  "Do you want to generate and compile the YarpRobotLoggerDevice?" ON
+  "Do you want to generate and compile the YarpRobotLoggerDevice?" OFF
   "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_YarpUtilities;FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_Math;FRAMEWORK_COMPILE_ContinuousDynamicalSystem;FRAMEWORK_USE_onnxruntime" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_VectorsCollectionWrapper

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -293,7 +293,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_YarpRobotLoggerDevice
   "FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_Camera;FRAMEWORK_COMPILE_YarpUtilities;FRAMEWORK_USE_robometry;FRAMEWORK_USE_trintrin" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_JointTorqueControlDevice
-  "Do you want to generate and compile the YarpRobotLoggerDevice?" OFF
+  "Do you want to generate and compile the JointTorqueControlDevice?" OFF
   "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_YarpUtilities;FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_Math;FRAMEWORK_COMPILE_ContinuousDynamicalSystem;FRAMEWORK_USE_onnxruntime" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_VectorsCollectionWrapper


### PR DESCRIPTION
## What changed

In `cmake/BipedalLocomotionFrameworkDependencies.cmake`, changed the default value from `ON` to `OFF` for three `framework_dependent_option` entries:

- `FRAMEWORK_COMPILE_FloatingBaseEstimators`
- `FRAMEWORK_COMPILE_RobotDynamicsEstimator`
- `FRAMEWORK_COMPILE_JointTorqueControlDevice`

This means the corresponding devices — `FloatingBaseEstimatorDevice`, `RobotDynamicsEstimatorDevice`, and `JointTorqueControlDevice` — are now **opt-in** rather than opt-out.

## Why

These components are optional and have heavyweight dependencies (manif, BayesFilters, onnxruntime). Defaulting them to OFF reduces build time for users who do not need them. Users who do need them can explicitly enable the options at configure time.
