### PR TITLE
Expose carrier option in BipedalLocomotion::RobotInterface::constructRemoteControlBoardRemapper

### DIFF
--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -61,6 +61,7 @@ struct PolyDriverDescriptor
  * |       `robot_name`      |     `string`     |                      Name of the robot                     |    Yes    |
  * |      `local_prefix`     |     `string`     |    Prefix of the local port (e.g. the application name)    |    Yes    |
  * |       `device`         |     `string`     | Name of the device to open. (Default value `remotecontrolboardremapper`) |     No    |
+ * |       `carrier`         |     `string`     | Carrier passed in `REMOTE_CONTROLBOARD_OPTIONS` (e.g. `udp`) |     No    |
  * @return A PolyDriverDescriptor. If one of the parameters is missing an invalid PolyDriverDescriptor is returned.
  */
 PolyDriverDescriptor constructRemoteControlBoardRemapper(

--- a/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
@@ -93,6 +93,12 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
     yarp::os::Property& remoteControlBoardsOpts = options.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
     remoteControlBoardsOpts.put("writeStrict", "on");
 
+    std::string carrier;
+    if (ptr->getParameter("carrier", carrier))
+    {
+        remoteControlBoardsOpts.put("carrier", carrier);
+    }
+
     PolyDriverDescriptor device("remoteControlBoards", std::make_shared<yarp::dev::PolyDriver>());
 
     if (!device.poly->open(options) && !device.poly->isValid())


### PR DESCRIPTION
This is useful to configure which carrier should be used, in case a nwc device using YARP ports is used.