### PR TITLE
Set reference position for a subset of joints

### DIFF
--- a/bindings/python/RobotInterface/src/DinRailRobotControl.cpp
+++ b/bindings/python/RobotInterface/src/DinRailRobotControl.cpp
@@ -36,13 +36,46 @@ void CreateDinRailRobotControl(pybind11::module& module)
             },
             py::arg("handler"))
         .def("set_driver", &DinRailRobotControl::setDriver, py::arg("driver"))
-        .def("set_impedance_set_points", //
-             &DinRailRobotControl::setImpedanceSetPoints,
+        .def("set_impedance_set_points",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>>(
+                 &DinRailRobotControl::setImpedanceSetPoints),
              py::arg("position"),
              py::arg("velocity"),
              py::arg("torque"),
              py::arg("stiffness"),
-             py::arg("damping"));
+             py::arg("damping"))
+        .def("set_impedance_set_points_subset",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               const std::vector<int>&>(
+                 &DinRailRobotControl::setImpedanceSetPoints),
+             py::arg("position"),
+             py::arg("velocity"),
+             py::arg("torque"),
+             py::arg("stiffness"),
+             py::arg("damping"),
+             py::arg("joint_indices"))
+        .def("set_impedance_set_points_by_name",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               Eigen::Ref<const Eigen::VectorXd>,
+                               const std::vector<std::string>&>(
+                 &DinRailRobotControl::setImpedanceSetPoints),
+             py::arg("position"),
+             py::arg("velocity"),
+             py::arg("torque"),
+             py::arg("stiffness"),
+             py::arg("damping"),
+             py::arg("joint_names"));
 }
 
 } // namespace RobotInterface

--- a/bindings/python/RobotInterface/src/YarpRobotControl.cpp
+++ b/bindings/python/RobotInterface/src/YarpRobotControl.cpp
@@ -64,6 +64,26 @@ void CreateYarpRobotControl(pybind11::module& module)
              py::arg("desired_joints_value"),
              py::arg("control_mode"),
              py::arg("current_joint_values") = std::nullopt)
+        .def("set_references",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               const std::vector<int>&,
+                               const IRobotControl::ControlMode&,
+                               std::optional<Eigen::Ref<const Eigen::VectorXd>>>(
+                 &YarpRobotControl::setReferences),
+             py::arg("desired_joints_value"),
+             py::arg("joint_indices"),
+             py::arg("control_mode"),
+             py::arg("current_joint_values") = std::nullopt)
+        .def("set_references",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               const std::vector<std::string>&,
+                               const IRobotControl::ControlMode&,
+                               std::optional<Eigen::Ref<const Eigen::VectorXd>>>(
+                 &YarpRobotControl::setReferences),
+             py::arg("desired_joints_value"),
+             py::arg("joint_names"),
+             py::arg("control_mode"),
+             py::arg("current_joint_values") = std::nullopt)
         .def("set_control_mode",
              py::overload_cast<const std::vector<IRobotControl::ControlMode>&>(
                  &YarpRobotControl::setControlMode),

--- a/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
+++ b/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
@@ -9,6 +9,7 @@
 #define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/Dense>
 
@@ -104,6 +105,60 @@ public:
                                Eigen::Ref<const Eigen::VectorXd> torque,
                                Eigen::Ref<const Eigen::VectorXd> stiffness,
                                Eigen::Ref<const Eigen::VectorXd> damping);
+
+    /**
+     * Set impedance control setpoints (MIT mode) for a subset of joints.
+     *
+     * Mirrors the behaviour of IRobotControl::setReferences() with joint indices:
+     * only the joints listed in @p jointIndices are updated; all other joints
+     * retain the values they were last commanded with.
+     *
+     * Each input vector must have exactly `jointIndices.size()` elements.  The
+     * same radian-to-degree conversion rules as the full overload apply.
+     *
+     * @param position   Position setpoints for the subset joints [rad].
+     * @param velocity   Velocity setpoints for the subset joints [rad/s].
+     * @param torque     Torque feedforward setpoints for the subset joints [Nm].
+     * @param stiffness  Stiffness setpoints for the subset joints [Nm/rad].
+     * @param damping    Damping setpoints for the subset joints [Nms/rad].
+     * @param jointIndices Indices (into the full control-board joint list) of the
+     *                     joints to update.
+     * @return True on success, false otherwise.
+     * @note The full overload must be called at least once before this overload
+     *       is used, so that the cached state for the non-indexed joints is
+     *       properly initialised.
+     */
+    bool setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
+                               Eigen::Ref<const Eigen::VectorXd> velocity,
+                               Eigen::Ref<const Eigen::VectorXd> torque,
+                               Eigen::Ref<const Eigen::VectorXd> stiffness,
+                               Eigen::Ref<const Eigen::VectorXd> damping,
+                               const std::vector<int>& jointIndices);
+
+    /**
+     * Set impedance control setpoints (MIT mode) for a subset of joints identified by name.
+     *
+     * Resolves each name in @p jointNames to its index in the controlled joint list and
+     * delegates to the index-based overload.  All other joints retain their last commanded
+     * setpoints.  Each input vector must have exactly `jointNames.size()` elements.
+     * The same unit-conversion rules as the full overload apply.
+     *
+     * @param position   Position setpoints for the named joints [rad].
+     * @param velocity   Velocity setpoints for the named joints [rad/s].
+     * @param torque     Torque feedforward setpoints for the named joints [Nm].
+     * @param stiffness  Stiffness setpoints for the named joints [Nm/rad].
+     * @param damping    Damping setpoints for the named joints [Nms/rad].
+     * @param jointNames Names of the joints to update (must be in the controlled joint list).
+     * @return True on success, false if any name is not found or inputs are inconsistent.
+     * @note The full overload must be called at least once before this overload
+     *       is used.
+     */
+    bool setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
+                               Eigen::Ref<const Eigen::VectorXd> velocity,
+                               Eigen::Ref<const Eigen::VectorXd> torque,
+                               Eigen::Ref<const Eigen::VectorXd> stiffness,
+                               Eigen::Ref<const Eigen::VectorXd> damping,
+                               const std::vector<std::string>& jointNames);
 };
 
 } // namespace RobotInterface

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -203,6 +203,12 @@ bool DinRailRobotControl::setDriver(std::shared_ptr<yarp::dev::PolyDriver> robot
     m_pimpl->stiffnessBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
     m_pimpl->dampingBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
 
+    m_pimpl->subsetPos.reserve(m_pimpl->actuatedDOFs);
+    m_pimpl->subsetVel.reserve(m_pimpl->actuatedDOFs);
+    m_pimpl->subsetTorque.reserve(m_pimpl->actuatedDOFs);
+    m_pimpl->subsetStiffness.reserve(m_pimpl->actuatedDOFs);
+    m_pimpl->subsetDamping.reserve(m_pimpl->actuatedDOFs);
+
     return true;
 }
 

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -38,8 +38,15 @@ struct DinRailRobotControl::Impl
      */
     std::vector<double> posBuffer;
     std::vector<double> velBuffer;
+    std::vector<double> torqueBuffer;
     std::vector<double> stiffnessBuffer;
     std::vector<double> dampingBuffer;
+
+    /**
+     * True after the first successful full setImpedanceSetPoints() call.
+     * The subset overload requires the cache to be initialised before use.
+     */
+    bool cacheInitialized{false};
 };
 
 DinRailRobotControl::DinRailRobotControl()
@@ -103,10 +110,11 @@ bool DinRailRobotControl::setDriver(std::shared_ptr<yarp::dev::PolyDriver> robot
     }
 
     // Pre-allocate conversion buffers.
-    m_pimpl->posBuffer.resize(m_pimpl->actuatedDOFs);
-    m_pimpl->velBuffer.resize(m_pimpl->actuatedDOFs);
-    m_pimpl->stiffnessBuffer.resize(m_pimpl->actuatedDOFs);
-    m_pimpl->dampingBuffer.resize(m_pimpl->actuatedDOFs);
+    m_pimpl->posBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
+    m_pimpl->velBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
+    m_pimpl->torqueBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
+    m_pimpl->stiffnessBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
+    m_pimpl->dampingBuffer.resize(m_pimpl->actuatedDOFs, 0.0);
 
     return true;
 }
@@ -164,7 +172,9 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
             m_pimpl->stiffnessBuffer[i] = stiffness[static_cast<Eigen::Index>(i)];
             m_pimpl->dampingBuffer[i] = damping[static_cast<Eigen::Index>(i)];
         }
+        m_pimpl->torqueBuffer[i] = torque[static_cast<Eigen::Index>(i)];
     }
+    m_pimpl->cacheInitialized = true;
 
     // Build non-owning VectorProxy views over the converted buffers.
     // VectorProxy<const double>::Ref can be constructed from any contiguous
@@ -172,7 +182,7 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
     // Eigen::Ref<const Eigen::VectorXd>.
     if (!m_pimpl->impedanceInterface->setSetPoints(m_pimpl->posBuffer,
                                                    m_pimpl->velBuffer,
-                                                   torque,
+                                                   m_pimpl->torqueBuffer,
                                                    m_pimpl->stiffnessBuffer,
                                                    m_pimpl->dampingBuffer))
     {
@@ -181,4 +191,110 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
     }
 
     return true;
+}
+
+bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
+                                                Eigen::Ref<const Eigen::VectorXd> velocity,
+                                                Eigen::Ref<const Eigen::VectorXd> torque,
+                                                Eigen::Ref<const Eigen::VectorXd> stiffness,
+                                                Eigen::Ref<const Eigen::VectorXd> damping,
+                                                const std::vector<int>& jointIndices)
+{
+    constexpr auto errorPrefix = "[DinRailRobotControl::setImpedanceSetPoints (subset)]";
+
+    if (m_pimpl->impedanceInterface == nullptr)
+    {
+        log()->error("{} The impedance interface is not ready. Did you call setDriver()?",
+                     errorPrefix);
+        return false;
+    }
+
+    if (!m_pimpl->cacheInitialized)
+    {
+        log()->error("{} Cache not initialised. Call the full setImpedanceSetPoints() overload "
+                     "at least once before using the subset overload.",
+                     errorPrefix);
+        return false;
+    }
+
+    const auto nSubset = static_cast<Eigen::Index>(jointIndices.size());
+
+    if (position.size() != nSubset || velocity.size() != nSubset || torque.size() != nSubset
+        || stiffness.size() != nSubset || damping.size() != nSubset)
+    {
+        log()->error("{} Input vector size mismatch. Expected {} (= jointIndices.size()) for all "
+                     "inputs. Got position={}, velocity={}, torque={}, stiffness={}, damping={}.",
+                     errorPrefix,
+                     nSubset,
+                     position.size(),
+                     velocity.size(),
+                     torque.size(),
+                     stiffness.size(),
+                     damping.size());
+        return false;
+    }
+
+    // Update only the indexed entries in the persistent full-size buffers.
+    constexpr double radToDeg = 180.0 / M_PI;
+    constexpr double degToRad = M_PI / 180.0;
+    for (Eigen::Index i = 0; i < nSubset; ++i)
+    {
+        const auto j = static_cast<std::size_t>(jointIndices[static_cast<std::size_t>(i)]);
+        if (m_pimpl->jointTypes[j] == JointType::REVOLUTE)
+        {
+            m_pimpl->posBuffer[j]       = radToDeg * position(i);
+            m_pimpl->velBuffer[j]       = radToDeg * velocity(i);
+            m_pimpl->stiffnessBuffer[j] = degToRad * stiffness(i);
+            m_pimpl->dampingBuffer[j]   = degToRad * damping(i);
+        } else
+        {
+            m_pimpl->posBuffer[j]       = position(i);
+            m_pimpl->velBuffer[j]       = velocity(i);
+            m_pimpl->stiffnessBuffer[j] = stiffness(i);
+            m_pimpl->dampingBuffer[j]   = damping(i);
+        }
+        m_pimpl->torqueBuffer[j] = torque(i);
+    }
+
+    // Forward the full (updated) cached buffers to the hardware.
+    if (!m_pimpl->impedanceInterface->setSetPoints(m_pimpl->posBuffer,
+                                                   m_pimpl->velBuffer,
+                                                   m_pimpl->torqueBuffer,
+                                                   m_pimpl->stiffnessBuffer,
+                                                   m_pimpl->dampingBuffer))
+    {
+        log()->error("{} Failed to set impedance setpoints.", errorPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
+                                                Eigen::Ref<const Eigen::VectorXd> velocity,
+                                                Eigen::Ref<const Eigen::VectorXd> torque,
+                                                Eigen::Ref<const Eigen::VectorXd> stiffness,
+                                                Eigen::Ref<const Eigen::VectorXd> damping,
+                                                const std::vector<std::string>& jointNames)
+{
+    constexpr auto errorPrefix = "[DinRailRobotControl::setImpedanceSetPoints (names)]";
+
+    const std::vector<std::string> controlledJoints = getJointList();
+
+    std::vector<int> jointIndices;
+    jointIndices.reserve(jointNames.size());
+    for (const auto& name : jointNames)
+    {
+        const auto it = std::find(controlledJoints.begin(), controlledJoints.end(), name);
+        if (it == controlledJoints.end())
+        {
+            log()->error("{} Joint '{}' not found in the controlled joint list.",
+                         errorPrefix, name);
+            return false;
+        }
+        jointIndices.push_back(
+            static_cast<int>(std::distance(controlledJoints.begin(), it)));
+    }
+
+    return setImpedanceSetPoints(position, velocity, torque, stiffness, damping, jointIndices);
 }

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include <yarp/dev/IAxisInfo.h>
@@ -41,6 +42,98 @@ struct DinRailRobotControl::Impl
     std::vector<double> torqueBuffer;
     std::vector<double> stiffnessBuffer;
     std::vector<double> dampingBuffer;
+
+    /**
+     * Scratch buffers for the subset overload of setImpedanceSetPoints().
+     * Protected by subsetMutex; acquired by the public API before calling
+     * setSetPointsSubset(), so that internal method itself does not need to lock.
+     */
+    std::mutex subsetMutex;
+    std::vector<double> subsetPos;
+    std::vector<double> subsetVel;
+    std::vector<double> subsetTorque;
+    std::vector<double> subsetStiffness;
+    std::vector<double> subsetDamping;
+    std::vector<int> subsetIndices;
+
+    /**
+     * Internal (non-locking) implementation of the subset impedance setpoint call.
+     * Caller must hold subsetMutex before invoking this method.
+     */
+    bool setSetPointsSubset(Eigen::Ref<const Eigen::VectorXd> position,
+                            Eigen::Ref<const Eigen::VectorXd> velocity,
+                            Eigen::Ref<const Eigen::VectorXd> torque,
+                            Eigen::Ref<const Eigen::VectorXd> stiffness,
+                            Eigen::Ref<const Eigen::VectorXd> damping,
+                            const std::vector<int>& jointIndices)
+    {
+        constexpr auto errorPrefix = "[DinRailRobotControl::setImpedanceSetPoints (subset)]";
+
+        if (this->impedanceInterface == nullptr)
+        {
+            log()->error("{} The impedance interface is not ready. Did you call setDriver()?",
+                         errorPrefix);
+            return false;
+        }
+
+        const auto nSubset = static_cast<Eigen::Index>(jointIndices.size());
+
+        if (position.size() != nSubset || velocity.size() != nSubset || torque.size() != nSubset
+            || stiffness.size() != nSubset || damping.size() != nSubset)
+        {
+            log()->error("{} Input vector size mismatch. Expected {} (= jointIndices.size()) for all "
+                         "inputs. Got position={}, velocity={}, torque={}, stiffness={}, damping={}.",
+                         errorPrefix,
+                         nSubset,
+                         position.size(),
+                         velocity.size(),
+                         torque.size(),
+                         stiffness.size(),
+                         damping.size());
+            return false;
+        }
+
+        // Resize scratch buffers (no allocation if capacity is sufficient).
+        this->subsetPos.resize(nSubset);
+        this->subsetVel.resize(nSubset);
+        this->subsetTorque.resize(nSubset);
+        this->subsetStiffness.resize(nSubset);
+        this->subsetDamping.resize(nSubset);
+
+        constexpr double radToDeg = 180.0 / M_PI;
+        constexpr double degToRad = M_PI / 180.0;
+        for (Eigen::Index i = 0; i < nSubset; ++i)
+        {
+            const auto j = static_cast<std::size_t>(jointIndices[static_cast<std::size_t>(i)]);
+            if (this->jointTypes[j] == JointType::REVOLUTE)
+            {
+                this->subsetPos[i]       = radToDeg * position(i);
+                this->subsetVel[i]       = radToDeg * velocity(i);
+                this->subsetStiffness[i] = degToRad * stiffness(i);
+                this->subsetDamping[i]   = degToRad * damping(i);
+            } else
+            {
+                this->subsetPos[i]       = position(i);
+                this->subsetVel[i]       = velocity(i);
+                this->subsetStiffness[i] = stiffness(i);
+                this->subsetDamping[i]   = damping(i);
+            }
+            this->subsetTorque[i] = torque(i);
+        }
+
+        if (!this->impedanceInterface->setSetPoints(jointIndices,
+                                                    this->subsetPos,
+                                                    this->subsetVel,
+                                                    this->subsetTorque,
+                                                    this->subsetStiffness,
+                                                    this->subsetDamping))
+        {
+            log()->error("{} Failed to set impedance setpoints.", errorPrefix);
+            return false;
+        }
+
+        return true;
+    }
 };
 
 DinRailRobotControl::DinRailRobotControl()
@@ -193,69 +286,8 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
                                                 Eigen::Ref<const Eigen::VectorXd> damping,
                                                 const std::vector<int>& jointIndices)
 {
-    constexpr auto errorPrefix = "[DinRailRobotControl::setImpedanceSetPoints (subset)]";
-
-    if (m_pimpl->impedanceInterface == nullptr)
-    {
-        log()->error("{} The impedance interface is not ready. Did you call setDriver()?",
-                     errorPrefix);
-        return false;
-    }
-
-    const auto nSubset = static_cast<Eigen::Index>(jointIndices.size());
-
-    if (position.size() != nSubset || velocity.size() != nSubset || torque.size() != nSubset
-        || stiffness.size() != nSubset || damping.size() != nSubset)
-    {
-        log()->error("{} Input vector size mismatch. Expected {} (= jointIndices.size()) for all "
-                     "inputs. Got position={}, velocity={}, torque={}, stiffness={}, damping={}.",
-                     errorPrefix,
-                     nSubset,
-                     position.size(),
-                     velocity.size(),
-                     torque.size(),
-                     stiffness.size(),
-                     damping.size());
-        return false;
-    }
-
-    // Convert to hardware units into subset-sized local buffers.
-    // The persistent cache is not touched; only the requested joints are sent.
-    constexpr double radToDeg = 180.0 / M_PI;
-    constexpr double degToRad = M_PI / 180.0;
-    std::vector<double> posSubset(nSubset), velSubset(nSubset), torqueSubset(nSubset),
-        stiffSubset(nSubset), dampSubset(nSubset);
-    for (Eigen::Index i = 0; i < nSubset; ++i)
-    {
-        const auto j = static_cast<std::size_t>(jointIndices[static_cast<std::size_t>(i)]);
-        if (m_pimpl->jointTypes[j] == JointType::REVOLUTE)
-        {
-            posSubset[i]   = radToDeg * position(i);
-            velSubset[i]   = radToDeg * velocity(i);
-            stiffSubset[i] = degToRad * stiffness(i);
-            dampSubset[i]  = degToRad * damping(i);
-        } else
-        {
-            posSubset[i]   = position(i);
-            velSubset[i]   = velocity(i);
-            stiffSubset[i] = stiffness(i);
-            dampSubset[i]  = damping(i);
-        }
-        torqueSubset[i] = torque(i);
-    }
-
-    if (!m_pimpl->impedanceInterface->setSetPoints(jointIndices,
-                                                   posSubset,
-                                                   velSubset,
-                                                   torqueSubset,
-                                                   stiffSubset,
-                                                   dampSubset))
-    {
-        log()->error("{} Failed to set impedance setpoints.", errorPrefix);
-        return false;
-    }
-
-    return true;
+    std::lock_guard<std::mutex> lock(m_pimpl->subsetMutex);
+    return m_pimpl->setSetPointsSubset(position, velocity, torque, stiffness, damping, jointIndices);
 }
 
 bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
@@ -269,8 +301,9 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
 
     const std::vector<std::string> controlledJoints = getJointList();
 
-    std::vector<int> jointIndices;
-    jointIndices.reserve(jointNames.size());
+    std::lock_guard<std::mutex> lock(m_pimpl->subsetMutex);
+    m_pimpl->subsetIndices.clear();
+    m_pimpl->subsetIndices.reserve(jointNames.size());
     for (const auto& name : jointNames)
     {
         const auto it = std::find(controlledJoints.begin(), controlledJoints.end(), name);
@@ -280,9 +313,9 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
                          errorPrefix, name);
             return false;
         }
-        jointIndices.push_back(
+        m_pimpl->subsetIndices.push_back(
             static_cast<int>(std::distance(controlledJoints.begin(), it)));
     }
 
-    return setImpedanceSetPoints(position, velocity, torque, stiffness, damping, jointIndices);
+    return m_pimpl->setSetPointsSubset(position, velocity, torque, stiffness, damping, m_pimpl->subsetIndices);
 }

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -209,14 +209,6 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
         return false;
     }
 
-    if (!m_pimpl->cacheInitialized)
-    {
-        log()->error("{} Cache not initialised. Call the full setImpedanceSetPoints() overload "
-                     "at least once before using the subset overload.",
-                     errorPrefix);
-        return false;
-    }
-
     const auto nSubset = static_cast<Eigen::Index>(jointIndices.size());
 
     if (position.size() != nSubset || velocity.size() != nSubset || torque.size() != nSubset
@@ -234,34 +226,37 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
         return false;
     }
 
-    // Update only the indexed entries in the persistent full-size buffers.
+    // Convert to hardware units into subset-sized local buffers.
+    // The persistent cache is not touched; only the requested joints are sent.
     constexpr double radToDeg = 180.0 / M_PI;
     constexpr double degToRad = M_PI / 180.0;
+    std::vector<double> posSubset(nSubset), velSubset(nSubset), torqueSubset(nSubset),
+        stiffSubset(nSubset), dampSubset(nSubset);
     for (Eigen::Index i = 0; i < nSubset; ++i)
     {
         const auto j = static_cast<std::size_t>(jointIndices[static_cast<std::size_t>(i)]);
         if (m_pimpl->jointTypes[j] == JointType::REVOLUTE)
         {
-            m_pimpl->posBuffer[j]       = radToDeg * position(i);
-            m_pimpl->velBuffer[j]       = radToDeg * velocity(i);
-            m_pimpl->stiffnessBuffer[j] = degToRad * stiffness(i);
-            m_pimpl->dampingBuffer[j]   = degToRad * damping(i);
+            posSubset[i]   = radToDeg * position(i);
+            velSubset[i]   = radToDeg * velocity(i);
+            stiffSubset[i] = degToRad * stiffness(i);
+            dampSubset[i]  = degToRad * damping(i);
         } else
         {
-            m_pimpl->posBuffer[j]       = position(i);
-            m_pimpl->velBuffer[j]       = velocity(i);
-            m_pimpl->stiffnessBuffer[j] = stiffness(i);
-            m_pimpl->dampingBuffer[j]   = damping(i);
+            posSubset[i]   = position(i);
+            velSubset[i]   = velocity(i);
+            stiffSubset[i] = stiffness(i);
+            dampSubset[i]  = damping(i);
         }
-        m_pimpl->torqueBuffer[j] = torque(i);
+        torqueSubset[i] = torque(i);
     }
 
-    // Forward the full (updated) cached buffers to the hardware.
-    if (!m_pimpl->impedanceInterface->setSetPoints(m_pimpl->posBuffer,
-                                                   m_pimpl->velBuffer,
-                                                   m_pimpl->torqueBuffer,
-                                                   m_pimpl->stiffnessBuffer,
-                                                   m_pimpl->dampingBuffer))
+    if (!m_pimpl->impedanceInterface->setSetPoints(jointIndices,
+                                                   posSubset,
+                                                   velSubset,
+                                                   torqueSubset,
+                                                   stiffSubset,
+                                                   dampSubset))
     {
         log()->error("{} Failed to set impedance setpoints.", errorPrefix);
         return false;

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -41,12 +41,6 @@ struct DinRailRobotControl::Impl
     std::vector<double> torqueBuffer;
     std::vector<double> stiffnessBuffer;
     std::vector<double> dampingBuffer;
-
-    /**
-     * True after the first successful full setImpedanceSetPoints() call.
-     * The subset overload requires the cache to be initialised before use.
-     */
-    bool cacheInitialized{false};
 };
 
 DinRailRobotControl::DinRailRobotControl()
@@ -174,7 +168,6 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
         }
         m_pimpl->torqueBuffer[i] = torque[static_cast<Eigen::Index>(i)];
     }
-    m_pimpl->cacheInitialized = true;
 
     // Build non-owning VectorProxy views over the converted buffers.
     // VectorProxy<const double>::Ref can be constructed from any contiguous

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -61,6 +61,7 @@ struct PolyDriverDescriptor
  * |       `robot_name`      |     `string`     |                      Name of the robot                     |    Yes    |
  * |      `local_prefix`     |     `string`     |    Prefix of the local port (e.g. the application name)    |    Yes    |
  * |       `device`         |     `string`     | Name of the device to open. (Default value `remotecontrolboardremapper`) |     No    |
+ * |       `carrier`         |     `string`     | Carrier passed in `REMOTE_CONTROLBOARD_OPTIONS` (e.g. `udp`) |     No    |
  * @return A PolyDriverDescriptor. If one of the parameters is missing an invalid PolyDriverDescriptor is returned.
  */
 PolyDriverDescriptor constructRemoteControlBoardRemapper(

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
@@ -153,6 +153,42 @@ public:
                   std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
 
     /**
+     * Set the desired reference for a subset of joints identified by their indices.
+     * @param desiredJointValues desired joint values for the subset (size must match jointIndices).
+     * @param jointIndices indices of the joints to control (into the full joint list).
+     * @param controlMode control mode for all the subset joints.
+     * @param currentJointValues current joint values for the subset (same size as desiredJointValues).
+     *        If not provided, the values are read from the hardware.
+     * @return True/False in case of success/failure.
+     * @note In case of position control the values have to be expressed in rad, in case of velocity
+     * control in rad/s. If the robot is controlled in torques, the desired joint values are
+     * expressed in Nm.
+     */
+    bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const std::vector<int>& jointIndices,
+                  const IRobotControl::ControlMode& controlMode,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
+
+    /**
+     * Set the desired reference for a subset of joints identified by their names.
+     * @param desiredJointValues desired joint values for the subset (size must match jointNames).
+     * @param jointNames names of the joints to control.
+     * @param controlMode control mode for all the subset joints.
+     * @param currentJointValues current joint values for the subset (same size as desiredJointValues).
+     *        If not provided, the values are read from the hardware.
+     * @return True/False in case of success/failure.
+     * @note In case of position control the values have to be expressed in rad, in case of velocity
+     * control in rad/s. If the robot is controlled in torques, the desired joint values are
+     * expressed in Nm.
+     */
+    bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const std::vector<std::string>& jointNames,
+                  const IRobotControl::ControlMode& controlMode,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
+
+    /**
      * Get the list of the controlled joints
      * @return A vector containing the name of the controlled joints.
      */

--- a/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
@@ -93,6 +93,12 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
     yarp::os::Property& remoteControlBoardsOpts = options.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
     remoteControlBoardsOpts.put("writeStrict", "on");
 
+    std::string carrier;
+    if (ptr->getParameter("carrier", carrier))
+    {
+        remoteControlBoardsOpts.put("carrier", carrier);
+    }
+
     PolyDriverDescriptor device("remoteControlBoards", std::make_shared<yarp::dev::PolyDriver>());
 
     if (!device.poly->open(options) && !device.poly->isValid())

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <future>
 #include <thread>
@@ -717,6 +718,213 @@ struct YarpRobotControl::Impl
                            this->controlModes.end(),
                            [&mode](const auto& m) { return m == mode; });
     }
+
+    bool setReferencesSubset(Eigen::Ref<const Eigen::VectorXd> jointValues,
+                             const std::vector<int>& jointIndices,
+                             const IRobotControl::ControlMode& controlMode,
+                             std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
+    {
+        constexpr auto errorPrefix = "[YarpRobotControl::Impl::setReferencesSubset]";
+
+        const int n = static_cast<int>(jointIndices.size());
+
+        if (jointValues.size() != n)
+        {
+            log()->error("{} desiredJointValues size ({}) does not match jointIndices size ({}).",
+                         errorPrefix,
+                         jointValues.size(),
+                         n);
+            return false;
+        }
+
+        if (controlMode == IRobotControl::ControlMode::Unknown
+            || controlMode == IRobotControl::ControlMode::Idle)
+        {
+            log()->error("{} Cannot set references for Idle or Unknown control mode.", errorPrefix);
+            return false;
+        }
+
+        // Validate indices
+        for (const int idx : jointIndices)
+        {
+            if (idx < 0 || static_cast<std::size_t>(idx) >= this->actuatedDOFs)
+            {
+                log()->error("{} Joint index {} is out of range [0, {}).",
+                             errorPrefix,
+                             idx,
+                             this->actuatedDOFs);
+                return false;
+            }
+        }
+
+        auto isScalingNotRequired = [](IRobotControl::ControlMode mode) -> bool {
+            return mode == IRobotControl::ControlMode::Torque
+                || mode == IRobotControl::ControlMode::PWM
+                || mode == IRobotControl::ControlMode::Current;
+        };
+
+        // For PositionDirect: check the error for the subset joints
+        if (controlMode == IRobotControl::ControlMode::PositionDirect)
+        {
+            if (currentJointValues.has_value())
+            {
+                if (currentJointValues->size() != n)
+                {
+                    log()->error(
+                        "{} currentJointValues size ({}) does not match jointIndices size ({}).",
+                        errorPrefix,
+                        currentJointValues->size(),
+                        n);
+                    return false;
+                }
+                for (int i = 0; i < n; i++)
+                {
+                    const double error
+                        = std::abs((*currentJointValues)[i] - jointValues[i]);
+                    if (error > this->positionDirectMaxAdmissibleError)
+                    {
+                        if (this->jointsTypeList[jointIndices[i]] == JointType::REVOLUTE)
+                        {
+                            log()->error(
+                                "{} The error between the current and the desired position of joint "
+                                "'{}' is greater than {} deg. Error = {} deg.",
+                                errorPrefix,
+                                this->axesName[jointIndices[i]],
+                                180.0 / M_PI * this->positionDirectMaxAdmissibleError,
+                                180.0 / M_PI * error);
+                        } else
+                        {
+                            log()->error(
+                                "{} The error between the current and the desired position of joint "
+                                "'{}' is greater than {}. Error = {}.",
+                                errorPrefix,
+                                this->axesName[jointIndices[i]],
+                                this->positionDirectMaxAdmissibleError,
+                                error);
+                        }
+                        return false;
+                    }
+                }
+            } else
+            {
+                if (!this->getJointPos())
+                {
+                    log()->error("{} Unable to get the joint position.", errorPrefix);
+                    return false;
+                }
+                for (int i = 0; i < n; i++)
+                {
+                    const double error
+                        = std::abs(this->positionFeedback[jointIndices[i]] - jointValues[i]);
+                    if (error > this->positionDirectMaxAdmissibleError)
+                    {
+                        if (this->jointsTypeList[jointIndices[i]] == JointType::REVOLUTE)
+                        {
+                            log()->error(
+                                "{} The error between the current and the desired position of joint "
+                                "'{}' is greater than {} deg. Error = {} deg.",
+                                errorPrefix,
+                                this->axesName[jointIndices[i]],
+                                180.0 / M_PI * this->positionDirectMaxAdmissibleError,
+                                180.0 / M_PI * error);
+                        } else
+                        {
+                            log()->error(
+                                "{} The error between the current and the desired position of joint "
+                                "'{}' is greater than {}. Error = {}.",
+                                errorPrefix,
+                                this->axesName[jointIndices[i]],
+                                this->positionDirectMaxAdmissibleError,
+                                error);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // For Position mode: compute reference speeds
+        if (controlMode == IRobotControl::ControlMode::Position)
+        {
+            Eigen::VectorXd currentPos(n);
+            if (currentJointValues.has_value())
+            {
+                if (currentJointValues->size() != n)
+                {
+                    log()->error(
+                        "{} currentJointValues size ({}) does not match jointIndices size ({}).",
+                        errorPrefix,
+                        currentJointValues->size(),
+                        n);
+                    return false;
+                }
+                currentPos = *currentJointValues;
+            } else
+            {
+                if (!this->getJointPos())
+                {
+                    log()->error("{} Unable to get the joint position.", errorPrefix);
+                    return false;
+                }
+                for (int i = 0; i < n; i++)
+                {
+                    currentPos[i] = this->positionFeedback[jointIndices[i]];
+                }
+            }
+
+            const double positioningDurationSeconds
+                = std::chrono::duration<double>(this->positioningDuration).count();
+            std::vector<double> refSpeeds(n);
+            for (int i = 0; i < n; i++)
+            {
+                const double jointError = std::abs(jointValues[i] - currentPos[i]);
+                double scaling, minVelocity;
+                if (this->jointsTypeList[jointIndices[i]] == JointType::REVOLUTE)
+                {
+                    scaling = 180.0 / M_PI;
+                    minVelocity = 3.0; // deg/s
+                } else
+                {
+                    scaling = 1.0;
+                    minVelocity = 10.0; // mm/s
+                }
+                refSpeeds[i] = std::max(minVelocity,
+                                        scaling * (jointError / positioningDurationSeconds));
+            }
+
+            if (!this->positionInterface->setRefSpeeds(n,
+                                                       jointIndices.data(),
+                                                       refSpeeds.data()))
+            {
+                log()->error("{} Unable to set the reference speed for the position control joints.",
+                             errorPrefix);
+                return false;
+            }
+
+            this->startPositionControlInstant = BipedalLocomotion::clock().now();
+        }
+
+        // Build desired values with unit conversion
+        Eigen::VectorXd refs(n);
+        for (int i = 0; i < n; i++)
+        {
+            double scaling = 1.0;
+            if (this->jointsTypeList[jointIndices[i]] == JointType::REVOLUTE
+                && !isScalingNotRequired(controlMode))
+            {
+                scaling = 180.0 / M_PI;
+            }
+            refs[i] = scaling * jointValues[i];
+        }
+
+        if (!this->control(controlMode)(n, jointIndices.data(), refs.data()))
+        {
+            log()->error("{} Unable to set the desired joint values.", errorPrefix);
+            return false;
+        }
+
+        return true;
+    }
 };
 
 YarpRobotControl::YarpRobotControl()
@@ -949,4 +1157,45 @@ bool YarpRobotControl::getJointLimits(Eigen::Ref<Eigen::VectorXd> lowerLimits,
         m_pimpl->controlLimitsInterface->getLimits(i, &lowerLimits[i], &upperLimits[i]);
     }
     return true;
+}
+
+bool YarpRobotControl::setReferences(
+    Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+    const std::vector<int>& jointIndices,
+    const IRobotControl::ControlMode& controlMode,
+    std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
+{
+    return m_pimpl->setReferencesSubset(desiredJointValues,
+                                        jointIndices,
+                                        controlMode,
+                                        currentJointValues);
+}
+
+bool YarpRobotControl::setReferences(
+    Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+    const std::vector<std::string>& jointNames,
+    const IRobotControl::ControlMode& controlMode,
+    std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
+{
+    constexpr auto errorPrefix = "[YarpRobotControl::setReferences]";
+
+    std::vector<int> jointIndices;
+    jointIndices.reserve(jointNames.size());
+    for (const auto& name : jointNames)
+    {
+        const auto it
+            = std::find(m_pimpl->axesName.begin(), m_pimpl->axesName.end(), name);
+        if (it == m_pimpl->axesName.end())
+        {
+            log()->error("{} Joint '{}' not found in the joint list.", errorPrefix, name);
+            return false;
+        }
+        jointIndices.push_back(
+            static_cast<int>(std::distance(m_pimpl->axesName.begin(), it)));
+    }
+
+    return m_pimpl->setReferencesSubset(desiredJointValues,
+                                        jointIndices,
+                                        controlMode,
+                                        currentJointValues);
 }

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -31,6 +31,12 @@
 
 using namespace BipedalLocomotion::RobotInterface;
 
+namespace
+{
+constexpr double RevolutePositionMinVelocity = 3.0; // deg/s
+constexpr double PrismaticPositionMinVelocity = 10.0; // mm/s
+}
+
 struct YarpRobotControl::Impl
 {
     /**
@@ -660,11 +666,11 @@ struct YarpRobotControl::Impl
                     if (this->jointsTypeList[i] == JointType::REVOLUTE)
                     {
                         scaling = 180 / M_PI;
-                        minVelocity = 3.0; // Degrees/sec
+                        minVelocity = RevolutePositionMinVelocity;
                     }
                     else {
                         scaling = 1;
-                        minVelocity = 10; // mm/sec
+                        minVelocity = PrismaticPositionMinVelocity;
                     }
                     this->positionControlRefSpeeds[i]
                         = std::max(minVelocity,
@@ -897,11 +903,11 @@ struct YarpRobotControl::Impl
                 if (this->jointsTypeList[jointIndices[i]] == JointType::REVOLUTE)
                 {
                     scaling = 180.0 / M_PI;
-                    minVelocity = 3.0; // deg/s
+                    minVelocity = RevolutePositionMinVelocity;
                 } else
                 {
                     scaling = 1.0;
-                    minVelocity = 10.0; // mm/s
+                    minVelocity = PrismaticPositionMinVelocity;
                 }
                 this->subsetRefSpeeds[i] = std::max(minVelocity,
                                         scaling * (jointError / positioningDurationSeconds));

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <future>
+#include <mutex>
 #include <thread>
 #include <unordered_map>
 
@@ -99,6 +100,14 @@ struct YarpRobotControl::Impl
                                             interfaces. */
     std::size_t readingTimeout{500}; /**< Timeout used while reading from the yarp interfaces in
                                         microseconds. */
+
+    /** Protects the scratch buffers below; acquired by the public subset-control API before any
+     *  call to setReferencesSubset(), so that method itself does not need to lock. */
+    std::mutex subsetMutex;
+    Eigen::VectorXd subsetCurrentPos; /**< Scratch: current joint positions for subset position mode. */
+    std::vector<double> subsetRefSpeeds; /**< Scratch: reference speeds for subset position mode. */
+    Eigen::VectorXd subsetRefs; /**< Scratch: converted reference values for subset calls. */
+    std::vector<int> subsetJointIndices; /**< Scratch: joint indices for name-based subset calls. */
 
     static IRobotControl::ControlMode
     YarpControlModeToControlMode(const yarp::conf::vocab32_t& controlModeYarp)
@@ -846,7 +855,7 @@ struct YarpRobotControl::Impl
         // For Position mode: compute reference speeds
         if (controlMode == IRobotControl::ControlMode::Position)
         {
-            Eigen::VectorXd currentPos(n);
+            this->subsetCurrentPos.resize(n);
             if (currentJointValues.has_value())
             {
                 if (currentJointValues->size() != n)
@@ -858,7 +867,7 @@ struct YarpRobotControl::Impl
                         n);
                     return false;
                 }
-                currentPos = *currentJointValues;
+                this->subsetCurrentPos = *currentJointValues;
             } else
             {
                 if (!this->getJointPos())
@@ -868,16 +877,16 @@ struct YarpRobotControl::Impl
                 }
                 for (int i = 0; i < n; i++)
                 {
-                    currentPos[i] = this->positionFeedback[jointIndices[i]];
+                    this->subsetCurrentPos[i] = this->positionFeedback[jointIndices[i]];
                 }
             }
 
             const double positioningDurationSeconds
                 = std::chrono::duration<double>(this->positioningDuration).count();
-            std::vector<double> refSpeeds(n);
+            this->subsetRefSpeeds.resize(n);
             for (int i = 0; i < n; i++)
             {
-                const double jointError = std::abs(jointValues[i] - currentPos[i]);
+                const double jointError = std::abs(jointValues[i] - this->subsetCurrentPos[i]);
                 double scaling, minVelocity;
                 if (this->jointsTypeList[jointIndices[i]] == JointType::REVOLUTE)
                 {
@@ -888,13 +897,13 @@ struct YarpRobotControl::Impl
                     scaling = 1.0;
                     minVelocity = 10.0; // mm/s
                 }
-                refSpeeds[i] = std::max(minVelocity,
+                this->subsetRefSpeeds[i] = std::max(minVelocity,
                                         scaling * (jointError / positioningDurationSeconds));
             }
 
             if (!this->positionInterface->setRefSpeeds(n,
                                                        jointIndices.data(),
-                                                       refSpeeds.data()))
+                                                       this->subsetRefSpeeds.data()))
             {
                 log()->error("{} Unable to set the reference speed for the position control joints.",
                              errorPrefix);
@@ -905,7 +914,7 @@ struct YarpRobotControl::Impl
         }
 
         // Build desired values with unit conversion
-        Eigen::VectorXd refs(n);
+        this->subsetRefs.resize(n);
         for (int i = 0; i < n; i++)
         {
             double scaling = 1.0;
@@ -914,10 +923,10 @@ struct YarpRobotControl::Impl
             {
                 scaling = 180.0 / M_PI;
             }
-            refs[i] = scaling * jointValues[i];
+            this->subsetRefs[i] = scaling * jointValues[i];
         }
 
-        if (!this->control(controlMode)(n, jointIndices.data(), refs.data()))
+        if (!this->control(controlMode)(n, jointIndices.data(), this->subsetRefs.data()))
         {
             log()->error("{} Unable to set the desired joint values.", errorPrefix);
             return false;
@@ -1165,6 +1174,7 @@ bool YarpRobotControl::setReferences(
     const IRobotControl::ControlMode& controlMode,
     std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
 {
+    std::lock_guard<std::mutex> lock(m_pimpl->subsetMutex);
     return m_pimpl->setReferencesSubset(desiredJointValues,
                                         jointIndices,
                                         controlMode,
@@ -1179,8 +1189,9 @@ bool YarpRobotControl::setReferences(
 {
     constexpr auto errorPrefix = "[YarpRobotControl::setReferences]";
 
-    std::vector<int> jointIndices;
-    jointIndices.reserve(jointNames.size());
+    std::lock_guard<std::mutex> lock(m_pimpl->subsetMutex);
+    m_pimpl->subsetJointIndices.clear();
+    m_pimpl->subsetJointIndices.reserve(jointNames.size());
     for (const auto& name : jointNames)
     {
         const auto it
@@ -1190,12 +1201,12 @@ bool YarpRobotControl::setReferences(
             log()->error("{} Joint '{}' not found in the joint list.", errorPrefix, name);
             return false;
         }
-        jointIndices.push_back(
+        m_pimpl->subsetJointIndices.push_back(
             static_cast<int>(std::distance(m_pimpl->axesName.begin(), it)));
     }
 
     return m_pimpl->setReferencesSubset(desiredJointValues,
-                                        jointIndices,
+                                        m_pimpl->subsetJointIndices,
                                         controlMode,
                                         currentJointValues);
 }

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -382,6 +382,12 @@ struct YarpRobotControl::Impl
         this->controlModesYarp.resize(this->actuatedDOFs);
         this->axesName.resize(this->actuatedDOFs);
 
+        // reserve vector for subset control
+        this->subsetCurrentPos.resize(this->actuatedDOFs);
+        this->subsetRefSpeeds.reserve(this->actuatedDOFs);
+        this->subsetRefs.resize(this->actuatedDOFs);
+        this->subsetJointIndices.reserve(this->actuatedDOFs);
+
         // populate the axesName vector
         for (int i = 0; i < this->actuatedDOFs; i++)
         {

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
@@ -106,6 +106,44 @@ public:
         = 0;
 
     /**
+     * Set the desired reference for a subset of joints identified by their indices.
+     * @param desiredJointValues desired joint values for the subset (size must match jointIndices).
+     * @param jointIndices indices of the joints to control (into the full joint list).
+     * @param controlMode control mode for all the subset joints.
+     * @param currentJointValues current joint values for the subset (same size as desiredJointValues).
+     *        If not provided, the values are read from the hardware.
+     * @return True/False in case of success/failure.
+     * @note In case of position control the values have to be expressed in rad, in case of velocity
+     * control in rad/s. If the robot is controlled in torques, the desired joint values are
+     * expressed in Nm.
+     */
+    virtual bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const std::vector<int>& jointIndices,
+                  const IRobotControl::ControlMode& controlMode,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
+        = 0;
+
+    /**
+     * Set the desired reference for a subset of joints identified by their names.
+     * @param desiredJointValues desired joint values for the subset (size must match jointNames).
+     * @param jointNames names of the joints to control.
+     * @param controlMode control mode for all the subset joints.
+     * @param currentJointValues current joint values for the subset (same size as desiredJointValues).
+     *        If not provided, the values are read from the hardware.
+     * @return True/False in case of success/failure.
+     * @note In case of position control the values have to be expressed in rad, in case of velocity
+     * control in rad/s. If the robot is controlled in torques, the desired joint values are
+     * expressed in Nm.
+     */
+    virtual bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const std::vector<std::string>& jointNames,
+                  const IRobotControl::ControlMode& controlMode,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
+        = 0;
+
+    /**
      * Set the control mode.
      * @param controlModes vector containing the control mode for each joint.
      * @return True/False in case of success/failure.

--- a/src/RobotInterface/src/IRobotControl.cpp
+++ b/src/RobotInterface/src/IRobotControl.cpp
@@ -13,3 +13,5 @@ bool IRobotControl::initialize(std::weak_ptr<ParametersHandler::IParametersHandl
 {
     return true;
 }
+
+


### PR DESCRIPTION
This PR adds 2 methods in `DinRailRobotControl` and in `IRobotControl`  to set only a subset of joints, specifying the joint indices or the joint names.