### PR TITLE
Allow vector of mixed integers and doubles in YarpParametersHandler

### DIFF
--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -224,6 +224,12 @@ TEST_CASE("Get parameters")
         }
 
         {
+            std::vector<double> element;
+            REQUIRE(cartoonsGroup->getParameter("fingersScaling", element));
+            REQUIRE(element == std::vector<double>{1.0, 2.0, 3.5, 3.5, 3.5});
+        }
+
+        {
             std::string element;
             REQUIRE(cartoonsGroup->getParameter("John", element));
             REQUIRE(element == "Doe");

--- a/src/ParametersHandler/tests/config.ini
+++ b/src/ParametersHandler/tests/config.ini
@@ -8,6 +8,7 @@ time_as_double                          0.05
 [CARTOONS]
 "Donald's nephews"                      ("Huey", "Dewey", "Louie")
 Fibonacci_Numbers                       (1, 1, 2, 3, 5, 8, 13, 21)
+fingersScaling                          (1, 2.0, 3.5, 3.5, 3.5)
 John                                    Doe
 
 [TIMINGS]

--- a/src/YarpUtilities/include/BipedalLocomotion/YarpUtilities/Helper.tpp
+++ b/src/YarpUtilities/include/BipedalLocomotion/YarpUtilities/Helper.tpp
@@ -41,7 +41,10 @@ template <typename T> bool isValueValid(const yarp::os::Value& value)
     }
     if constexpr (std::is_same<T, double>::value)
     {
-        return value.isFloat64();
+        // YARP stores integral and floating-point tokens using different types. An integer is
+        // nevertheless a valid value for a double parameter and asFloat64() performs the
+        // corresponding numeric conversion.
+        return value.isFloat64() || value.isInt32();
     }
     if constexpr (std::is_same<T, float>::value)
     {


### PR DESCRIPTION
Until this fix,  did not supported the following as a vector of doubles:

~~~
fingersScaling                          (1, 2.0, 3.5, 3.5, 3.5)
~~~

this emerged by testing the existing parser on existing configuration files, see https://github.com/gbionics/walking-teleoperation/blob/6aa801a0f4e62303dfe54b36234ffa459d3a03b0/app/robots/ergoCubSN002/openXRJoypad.ini#L22 .